### PR TITLE
fix for clip-path ids carried to another image-mask

### DIFF
--- a/src/image-mask.html
+++ b/src/image-mask.html
@@ -4,7 +4,7 @@
 	<template>
 	    <svg width="{{size}}" height="{{size}}" viewBox="0 0 {{size}} {{size}}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">		
 			<g>
-				<clipPath id="{{shape}}">
+				<clipPath id="{{maskId}}">
 
 				    <template if="{{shape == 'circle'}}">
 						<circle r="50%" cx="50%" cy="50%"/>
@@ -33,7 +33,7 @@
 				</clipPath>
 			</g>
 			<a xlink:href="{{href}}" id="link" xlink:title="{{title}}">
-				<image clip-path="url(#{{shape}})" height="100%" width="100%" xlink:href="{{src}}"  preserveAspectRatio="xMidYMin slice" />
+				<image clip-path="url(#{{maskId}})" height="100%" width="100%" xlink:href="{{src}}"  preserveAspectRatio="xMidYMin slice" />
 			</a>
 		</svg>
     </template>
@@ -42,6 +42,7 @@
 			shape: "circle",
 			size: "320",
 			ready: function() {
+				this.maskId = "mask-"+Math.random().toString(36).substr(2, 5);
 				if(!this.href) {
 					this.href = this.$.link.removeAttribute("xlink:href");
 				}


### PR DESCRIPTION
Thanks for the component. 
I had a weird problem (which I wasn't able to reproduce in demo.html) where clip-paths with the same id (e.g. {{shape}}) were not encapsulated within the component so it was carried to another image-mask. So the shape in one would affect the other one. 

A unique maskId for each image-mask component solved that problem and I don't think it would cause any problem.